### PR TITLE
string argument passed to function seems to be frozen by default

### DIFF
--- a/lib/gitrb/repository.rb
+++ b/lib/gitrb/repository.rb
@@ -44,7 +44,7 @@ module Gitrb
       @logger  = options[:logger] || Logger.new(nil)
       @encoding = options[:encoding] || DEFAULT_ENCODING
 
-      @path = options[:path]
+      @path = options[:path].dup
       @path.chomp!('/')
       @path += '/.git' if !@bare
 


### PR DESCRIPTION
This popped up when I tried to use gitrb with Olelo. Without this patch it stopped with RuntimeError. With it so far seems to work.
