### PR TITLE
Recent versions of git refuse -700, must be -0700

### DIFF
--- a/lib/gitrb/user.rb
+++ b/lib/gitrb/user.rb
@@ -11,7 +11,7 @@ module Gitrb
 
     def dump
       off = date.gmt_offset / 60
-      '%s <%s> %d %s%02d%02d' % [name, email, date.to_i, off < 0 ? '' : '+', off / 60, off % 60]
+      '%s <%s> %d %s%02d%02d' % [name, email, date.to_i, off < 0 ? '-' : '+', off.abs / 60, off % 60]
     end
 
     def self.parse(user)


### PR DESCRIPTION
According to this Git commit, gitrb was creating invalid commits: https://github.com/git/git/commit/daae19224a05be9efb9a39c2a2c1c9a60fe906f1
